### PR TITLE
feature/Awais/added_colNameSplitter_prop_to_display_column_name_with_…

### DIFF
--- a/src/DataTable.js
+++ b/src/DataTable.js
@@ -22,6 +22,7 @@ class DataTable extends React.Component {
         data: [], //[{...}, {...}, ....]
         displayData: [], //currentlyDisplayData
         colNames: [],//['ad', 'asd', ...]
+        colNameSplitter: null,
         defaultEachColumnWidth: '50%',
         // noOfCols: 0, //default 2, set 0 because of fast rendering at start
         widthOfContainer: 0,
@@ -112,12 +113,21 @@ class DataTable extends React.Component {
         //Here below code means that data prop is changed
         let data = props?.data
         let colNames = props?.colNames;
+        let colNameSplitter = props?.colNameSplitter;
 
         if (typeof (data) != 'object') {
             data = [];
         }
         if (typeof (colNames) != 'object') {
             colNames = ['No Columns'];
+        }
+        if (colNameSplitter != null) {
+            if (typeof (colNameSplitter) != 'string') {
+                if (colNameSplitter.length != 1) {
+                    // colNameSplitter should be single character
+                    colNameSplitter = null;
+                }
+            }
         }
 
         const mapColNameToType = {}
@@ -152,6 +162,7 @@ class DataTable extends React.Component {
             data: modifiedData,
             displayData: modifiedData.slice(0, end[0]?.endData),
             colNames: [...colNames],
+            colNameSplitter: colNameSplitter,
             defaultEachColumnWidth: TOTAL_WIDTH / noOfCols + '%',
             isSortedAssending: { ...currentState.isSortedAssending, ...isSortedAssending },
             activeDisplayDataId: 0, //by default it's zero
@@ -171,6 +182,7 @@ class DataTable extends React.Component {
 
                 <DataTableHeader
                     colNames={this.state.colNames}
+                    colNameSplitter={this.state.colNameSplitter}
                     mapColNameToType={this.state.mapColNameToType}
                     defaultEachColumnWidth={this.state.defaultEachColumnWidth}
                     handleColPress={this.handleColPress}

--- a/src/DataTableHeader.js
+++ b/src/DataTableHeader.js
@@ -7,7 +7,7 @@ const PADDING_TOP = 20;
 
 const DataTableHeader = React.memo((props) => {
 
-    const {colNames, mapColNameToType, defaultEachColumnWidth, handleColPress} = props;
+    const { colNames, mapColNameToType, defaultEachColumnWidth, handleColPress, colNameSplitter} = props;
     
     return (
         <View style={styles.headerContainer}>
@@ -27,7 +27,7 @@ const DataTableHeader = React.memo((props) => {
                     if (colType == COL_TYPES.CHECK_BOX){
                         return (
                             <View style={[styles.headerRow, { width: defaultEachColumnWidth, justifyContent }]}>
-                                <Text style={[styles.headerLabel, {textAlign: 'center'}]}>{' ' + colName[0].toUpperCase() + colName.substring(1)}</Text>
+                                <Text style={[styles.headerLabel, { textAlign: 'center' }]}>{colName.replaceAll(colNameSplitter, " \n")}</Text>
                             </View>
                         )
                     }
@@ -41,7 +41,7 @@ const DataTableHeader = React.memo((props) => {
                                     style={[styles.headerLabel, {
                                         paddingRight
                                     }]}>
-                                    {' ' + colName[0].toUpperCase() + colName.substring(1)}
+                                    {colName.replaceAll(colNameSplitter, " \n")}
                                 </Text>
                             </View>
                         </TouchableOpacity>
@@ -71,6 +71,9 @@ const styles = StyleSheet.create({
     },
     headerLabel: {
         color: 'grey',
-        fontSize: 12
+        fontSize: 12,
+        fontWeight: "bold",
+        textTransform:"uppercase"
+        //flex wrap not working here
     }
 });


### PR DESCRIPTION
this componant did not allow the spaces in column name so i added a prop to to split column name ob the base of any character and replace that using with space.
this feature only apply changes to display names of columns,not there actual keys.

now we can read column names more clearly on small screen devices where column names will not overlap.

new prop:
colNameSplitter

prop type:
single character string

example: (props passed)
data[{the_first_column : 'value'}]
colNames : ["the_first_column"]
colNameSplitter : {"_"}

output column name will be:
THE
FIRST
COLUMN

(behaves like wrap property of css)
